### PR TITLE
Fix infinite model-reload loop and download-aware startup timeout (#1)

### DIFF
--- a/src/mlx_serve/config.py
+++ b/src/mlx_serve/config.py
@@ -113,6 +113,14 @@ def _load() -> tuple[dict[str, ModelConfig], int, int, int, int, MonitoringConfi
         data.get("manager_port", 8095),
         data.get("inactivity_timeout_seconds", 600),
         data.get("startup_timeout_seconds", 120),
+        # Max wait for a first-time model download (HF pull) to finish. Far
+        # larger than startup_timeout because multi-GB weights can't arrive in
+        # 120s. Only applied when the model is not yet in the HF cache.
+        data.get("download_timeout_seconds", 1800),
+        # After a model fails to load, reject further requests for it for this
+        # many seconds instead of respawning on every retry (prevents the
+        # infinite reload loop when a client auto-retries).
+        data.get("failure_cooldown_seconds", 30),
         monitoring,
     )
 
@@ -123,6 +131,8 @@ def _load() -> tuple[dict[str, ModelConfig], int, int, int, int, MonitoringConfi
     MANAGER_PORT,
     INACTIVITY_TIMEOUT,
     STARTUP_TIMEOUT,
+    DOWNLOAD_TIMEOUT,
+    FAILURE_COOLDOWN,
     MONITORING,
 ) = _load()
 

--- a/src/mlx_serve/events.py
+++ b/src/mlx_serve/events.py
@@ -29,6 +29,7 @@ class EventType(StrEnum):
     SERVER_SHUTDOWN = "server.shutdown"
 
     # Model lifecycle
+    MODEL_DOWNLOADING = "model.downloading"
     MODEL_LOADING = "model.loading"
     MODEL_READY = "model.ready"
     MODEL_FAILED = "model.failed"

--- a/src/mlx_serve/process_manager.py
+++ b/src/mlx_serve/process_manager.py
@@ -38,6 +38,7 @@ _LOG_DIR = pathlib.Path(tempfile.gettempdir()) / "mlx-manager-logs"
 class ModelState(Enum):
     IDLE = "idle"
     LOADING = "loading"
+    DOWNLOADING = "downloading"
     READY = "ready"
     FAILED = "failed"
 
@@ -54,10 +55,60 @@ _stderr_log_handle = None
 _inactivity_timeout: int = config.INACTIVITY_TIMEOUT  # overridable per-request
 _loading_started_at: float | None = None  # monotonic time when loading began
 
+# Failure tracking (circuit breaker / cooldown)
+_last_failure_at: float | None = None  # monotonic timestamp of last failure
+_last_failed_model: str | None = None
+_last_failure_reason: str | None = None
+
 
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _record_failure(model_name: str, reason: str) -> None:
+    """Record a model load failure for cooldown tracking."""
+    global _last_failure_at, _last_failed_model, _last_failure_reason
+    _last_failure_at = time.monotonic()
+    _last_failed_model = model_name
+    _last_failure_reason = reason
+
+
+def _clear_failure() -> None:
+    """Reset failure tracking state."""
+    global _last_failure_at, _last_failed_model, _last_failure_reason
+    _last_failure_at = None
+    _last_failed_model = None
+    _last_failure_reason = None
+
+
+def _failure_cooldown_remaining(model_name: str) -> float:
+    """Return seconds remaining in the failure cooldown for this model, or 0.0."""
+    if _last_failure_at is None or _last_failed_model != model_name:
+        return 0.0
+    elapsed = time.monotonic() - _last_failure_at
+    if elapsed >= config.FAILURE_COOLDOWN:
+        return 0.0
+    return config.FAILURE_COOLDOWN - elapsed
+
+
+def _is_model_cached(model_cfg: config.ModelConfig) -> bool:
+    """Return True if the model's weights are already in the HuggingFace cache."""
+    try:
+        from huggingface_hub import try_to_load_from_cache
+        from huggingface_hub.file_download import _CACHED_NO_EXIST
+
+        result = try_to_load_from_cache(model_cfg.hf_path, "config.json")
+        return isinstance(result, str) and result is not _CACHED_NO_EXIST
+    except Exception:
+        return False
+
+
+def _readiness_timeout(model_cfg: config.ModelConfig) -> int:
+    """Return the appropriate readiness timeout for this model."""
+    if not _is_model_cached(model_cfg):
+        return config.DOWNLOAD_TIMEOUT
+    return config.STARTUP_TIMEOUT
 
 
 def _build_command(model_cfg: config.ModelConfig) -> list[str]:
@@ -84,8 +135,12 @@ def _build_command(model_cfg: config.ModelConfig) -> list[str]:
     return cmd
 
 
-def _diagnose_failure() -> dict:
-    """Inspect subprocess state and stderr to determine failure reason."""
+def _diagnose_failure(timeout_seconds: int | None = None) -> dict:
+    """Inspect subprocess state and stderr to determine failure reason.
+
+    ``timeout_seconds`` is the readiness deadline that was actually applied
+    (download vs. startup), reported back when the failure is a timeout.
+    """
     detail: dict = {}
 
     if _process is not None and _process.poll() is not None:
@@ -93,7 +148,9 @@ def _diagnose_failure() -> dict:
         detail["reason"] = "process_crash"
     else:
         detail["reason"] = "startup_timeout"
-        detail["timeout_seconds"] = config.STARTUP_TIMEOUT
+        detail["timeout_seconds"] = (
+            timeout_seconds if timeout_seconds is not None else config.STARTUP_TIMEOUT
+        )
 
     if _stderr_log_path and _stderr_log_path.exists():
         lines = _stderr_log_path.read_text().splitlines()
@@ -153,17 +210,20 @@ async def _terminate_current() -> None:
 async def _health_check_loop() -> None:
     """Poll /health every 2s until READY or startup timeout."""
     global _state
-    deadline = datetime.now(UTC) + timedelta(seconds=config.STARTUP_TIMEOUT)
+    model_cfg = config.MODELS.get(_active_model) if _active_model else None
+    readiness_timeout = _readiness_timeout(model_cfg) if model_cfg else config.STARTUP_TIMEOUT
+    deadline = datetime.now(UTC) + timedelta(seconds=readiness_timeout)
     async with httpx.AsyncClient() as client:
         while datetime.now(UTC) < deadline:
             # Detect early process exit
             if _process is not None and _process.poll() is not None:
                 _state = ModelState.FAILED
                 _ready_event.set()
-                detail = _diagnose_failure()
+                detail = _diagnose_failure(timeout_seconds=readiness_timeout)
                 load_ms = (
                     (time.monotonic() - _loading_started_at) * 1000 if _loading_started_at else None
                 )
+                _record_failure(_active_model, detail.get("reason", "unknown"))
                 events.emit(
                     events.EventType.MODEL_FAILED,
                     model=_active_model,
@@ -189,6 +249,7 @@ async def _health_check_loop() -> None:
                 if resp.status_code == 200:
                     _state = ModelState.READY
                     _ready_event.set()
+                    _clear_failure()
                     load_ms = (
                         (time.monotonic() - _loading_started_at) * 1000
                         if _loading_started_at
@@ -229,8 +290,9 @@ async def _health_check_loop() -> None:
     # Timed out
     _state = ModelState.FAILED
     _ready_event.set()
-    detail = _diagnose_failure()
+    detail = _diagnose_failure(timeout_seconds=readiness_timeout)
     load_ms = (time.monotonic() - _loading_started_at) * 1000 if _loading_started_at else None
+    _record_failure(_active_model, detail.get("reason", "unknown"))
     events.emit(
         events.EventType.MODEL_FAILED,
         model=_active_model,
@@ -238,7 +300,7 @@ async def _health_check_loop() -> None:
         duration_ms=load_ms,
     )
     logger.error(
-        f"Model {_active_model} timed out after {config.STARTUP_TIMEOUT}s (logs: {_stderr_log_path})"
+        f"Model {_active_model} timed out after {readiness_timeout}s (logs: {_stderr_log_path})"
     )
 
 
@@ -264,10 +326,18 @@ async def _switch_model(model_name: str) -> None:
         await _terminate_current()
 
         model_cfg = config.MODELS[model_name]
+        cached = _is_model_cached(model_cfg)
         _ready_event.clear()
-        _state = ModelState.LOADING
+        _state = ModelState.DOWNLOADING if not cached else ModelState.LOADING
         _active_model = model_name
         _loading_started_at = time.monotonic()
+
+        if not cached:
+            events.emit(
+                events.EventType.MODEL_DOWNLOADING,
+                model=model_name,
+                detail={"hf_path": model_cfg.hf_path},
+            )
 
         _LOG_DIR.mkdir(exist_ok=True)
         _stderr_log_path = _LOG_DIR / f"{model_name}.log"
@@ -315,14 +385,27 @@ async def ensure_model(model_name: str) -> bool:
         _last_request_at = datetime.now(UTC)
         return False  # already warm
 
+    cooldown = _failure_cooldown_remaining(model_name)
+    if cooldown > 0:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                f"Model {model_name} recently failed ({_last_failure_reason}); "
+                f"retry in {cooldown:.0f}s"
+            ),
+        )
+
     cold_start = True
 
     if _active_model != model_name or _state in (ModelState.IDLE, ModelState.FAILED):
         await _switch_model(model_name)
 
-    if _state == ModelState.LOADING:
+    if _state in (ModelState.LOADING, ModelState.DOWNLOADING):
+        model_cfg = config.MODELS[model_name]
         with contextlib.suppress(TimeoutError):
-            await asyncio.wait_for(_ready_event.wait(), timeout=config.STARTUP_TIMEOUT + 5)
+            await asyncio.wait_for(_ready_event.wait(), timeout=_readiness_timeout(model_cfg) + 5)
 
     if _state == ModelState.FAILED:
         from fastapi import HTTPException

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -1,0 +1,134 @@
+"""Tests for process_manager lifecycle logic: failure cooldown and
+download-aware startup timeout.
+
+These exercise the pure decision helpers plus ensure_model/_switch_model
+behavior, without spawning real MLX subprocesses.
+"""
+
+import importlib
+import time
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture()
+def pm(tmp_config, log_dir):
+    """Reload config + process_manager against the temp config, fresh state."""
+    import mlx_serve.config
+
+    importlib.reload(mlx_serve.config)
+    import mlx_serve.events as events
+
+    events.configure(log_dir)
+
+    import mlx_serve.process_manager as process_manager
+
+    importlib.reload(process_manager)
+    return process_manager
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — failure cooldown / circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_failure_cooldown_blocks_recent_failure(pm):
+    pm._record_failure("test-text-model", "startup_timeout")
+    assert pm._failure_cooldown_remaining("test-text-model") > 0
+
+
+def test_failure_cooldown_expires_after_window(pm):
+    pm._record_failure("test-text-model", "startup_timeout")
+    # Pretend the failure happened a full cooldown ago.
+    pm._last_failure_at = time.monotonic() - (pm.config.FAILURE_COOLDOWN + 1)
+    assert pm._failure_cooldown_remaining("test-text-model") == 0
+
+
+def test_failure_cooldown_only_affects_failed_model(pm):
+    pm._record_failure("test-text-model", "startup_timeout")
+    assert pm._failure_cooldown_remaining("test-vision-model") == 0
+
+
+def test_clear_failure_resets_cooldown(pm):
+    pm._record_failure("test-text-model", "startup_timeout")
+    pm._clear_failure()
+    assert pm._failure_cooldown_remaining("test-text-model") == 0
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_short_circuits_during_cooldown(pm, monkeypatch):
+    """A request for a recently-failed model returns 503 immediately and
+    does NOT spawn another subprocess (the infinite-respawn bug)."""
+    spawned = False
+
+    async def fake_switch(model_name):
+        nonlocal spawned
+        spawned = True
+
+    monkeypatch.setattr(pm, "_switch_model", fake_switch)
+    pm._record_failure("test-text-model", "startup_timeout")
+
+    with pytest.raises(HTTPException) as exc:
+        await pm.ensure_model("test-text-model")
+
+    assert exc.value.status_code == 503
+    assert spawned is False
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — download-aware readiness timeout + downloading state/event
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_timeout_uses_download_timeout_when_not_cached(pm, monkeypatch):
+    monkeypatch.setattr(pm, "_is_model_cached", lambda cfg: False)
+    cfg = pm.config.MODELS["test-text-model"]
+    assert pm._readiness_timeout(cfg) == pm.config.DOWNLOAD_TIMEOUT
+
+
+def test_readiness_timeout_uses_startup_timeout_when_cached(pm, monkeypatch):
+    monkeypatch.setattr(pm, "_is_model_cached", lambda cfg: True)
+    cfg = pm.config.MODELS["test-text-model"]
+    assert pm._readiness_timeout(cfg) == pm.config.STARTUP_TIMEOUT
+
+
+def test_diagnose_failure_reports_actual_timeout(pm):
+    """On a startup/download timeout, the reported timeout_seconds reflects the
+    deadline actually used, not the bare STARTUP_TIMEOUT."""
+
+    class StillRunning:
+        returncode = None
+
+        def poll(self):
+            return None  # process alive -> this is a timeout, not a crash
+
+    pm._process = StillRunning()
+    detail = pm._diagnose_failure(timeout_seconds=pm.config.DOWNLOAD_TIMEOUT)
+    assert detail["reason"] == "startup_timeout"
+    assert detail["timeout_seconds"] == pm.config.DOWNLOAD_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_switch_emits_downloading_event_when_not_cached(pm, monkeypatch):
+    """When a model isn't cached, the switch enters DOWNLOADING and emits a
+    model.downloading event so the hang is visible to the user."""
+    import mlx_serve.events as events
+
+    monkeypatch.setattr(pm, "_is_model_cached", lambda cfg: False)
+
+    class FakeProc:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(pm.subprocess, "Popen", lambda *a, **k: FakeProc())
+    # Don't run the real health loop (would poll a nonexistent server).
+    monkeypatch.setattr(pm.asyncio, "create_task", lambda coro: coro.close())
+
+    await pm._switch_model("test-text-model")
+
+    downloading = events.get_events(event_type="model.downloading")
+    assert any(e["model"] == "test-text-model" for e in downloading)
+    assert pm._state == pm.ModelState.DOWNLOADING


### PR DESCRIPTION
Fixes #1.

## Root cause

`mlx_lm.server` loads (and, on first run, **downloads**) the model *before* it binds its HTTP socket — `ModelProvider.__init__` calls `load()` eagerly and only then does `run()` start `serve_forever()`. So the manager's `GET /health` poll can't succeed until the entire HF download + weight load finishes.

That produced two compounding bugs:

1. **First-run download blows the 120s `startup_timeout`.** A multi-GB (or ~20GB 35B) download can't finish in 120s, so the manager declares `startup_timeout` even though nothing is broken — it's just downloading.
2. **No backoff on FAILED → infinite respawn.** `ensure_model` re-triggered a full `_switch_model` for any request while state was `IDLE`/`FAILED`. A client that auto-retries (e.g. OpenCode) kicked off a fresh 120s attempt on every retry, throwing away partial download progress — the endless `model.failed → model.switch.start → subprocess.spawned` loop seen in the issue.

## Changes

- **Download-aware readiness timeout.** `_is_model_cached()` checks the HF cache; uncached models use `download_timeout_seconds` (default **1800s**) instead of the 120s `startup_timeout`. New `DOWNLOADING` state + `model.downloading` event make a long first pull visible.
- **Failure cooldown / circuit breaker.** After a load failure, requests for that model get an immediate **503** (with the real reason) for `failure_cooldown_seconds` (default **30s**) instead of respawning. Cleared on a successful load.
- **Accurate failure reporting.** `model.failed` now reports the readiness deadline actually applied, not always the bare `startup_timeout`.

New optional `models.yaml` keys: `download_timeout_seconds`, `failure_cooldown_seconds` (sensible defaults, no config change required).

## Tests

Adds `tests/test_process_manager.py` (cooldown window, per-model scoping, 503 short-circuit without respawn, download-vs-startup timeout selection, downloading event/state, accurate timeout reporting). Full suite: **51 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)